### PR TITLE
Avoid unsafe unsafe.Pointer usage

### DIFF
--- a/go/arrow/memory/memory_avx2_amd64.go
+++ b/go/arrow/memory/memory_avx2_amd64.go
@@ -21,7 +21,7 @@ package memory
 import "unsafe"
 
 //go:noescape
-func _memset_avx2(buf, len, c unsafe.Pointer)
+func _memset_avx2(buf unsafe.Pointer, len, c uintptr)
 
 func memory_memset_avx2(buf []byte, c byte) {
 	if len(buf) == 0 {
@@ -30,8 +30,8 @@ func memory_memset_avx2(buf []byte, c byte) {
 
 	var (
 		p1 = unsafe.Pointer(&buf[0])
-		p2 = unsafe.Pointer(uintptr(len(buf)))
-		p3 = unsafe.Pointer(uintptr(c))
+		p2 = uintptr(len(buf))
+		p3 = uintptr(c)
 	)
 	if len(buf) > 2000 || isMultipleOfPowerOf2(len(buf), 256) {
 		_memset_avx2(p1, p2, p3)

--- a/go/arrow/memory/memory_sse4_amd64.go
+++ b/go/arrow/memory/memory_sse4_amd64.go
@@ -21,11 +21,11 @@ package memory
 import "unsafe"
 
 //go:noescape
-func _memset_sse4(buf, len, c unsafe.Pointer)
+func _memset_sse4(buf unsafe.Pointer, len, c uintptr)
 
 func memory_memset_sse4(buf []byte, c byte) {
 	if len(buf) == 0 {
 		return
 	}
-	_memset_sse4(unsafe.Pointer(&buf[0]), unsafe.Pointer(uintptr(len(buf))), unsafe.Pointer(uintptr(c)))
+	_memset_sse4(unsafe.Pointer(&buf[0]), uintptr(len(buf)), uintptr(c))
 }


### PR DESCRIPTION
The checkptr check in go 1.14 flags `unsafe.Pointer(uintptr(x))` as potentially unsafe due to the possibility of dereferencing arbitrary memory.  This commit instead uses bare pointers for the length & byte fields